### PR TITLE
Allow automating player enderchests

### DIFF
--- a/milo/apis/storage.lua
+++ b/milo/apis/storage.lua
@@ -489,7 +489,7 @@ function Storage:_sn(name)
 end
 
 local function isValidTransfer(adapter, target)
-	if string.find(target,":inventory") or string.find(target,":equipment") then
+	if string.find(target,":inventory") or string.find(target,":equipment") or string.find(target,":enderChest") then
 		return false
 	end
 	-- lazily cache transfer locations


### PR DESCRIPTION
Milo would refuse to automate import/exports on player enderchests unless `isValidTransfer` returns false for the target, this fixes it to behave the same as player inventories and equipment.